### PR TITLE
Link to public security documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ See [Upgrading](https://docs.openc3.com/docs/getting-started/upgrading) for more
 
 ## Change all default credentials and secrets
 
+For detailed explanations of all COSMOS credentials and security best practices, see the [Security documentation](https://docs.openc3.com/docs/getting-started/security).
+
 1. Edit .env and change:
    1. SECRET_KEY_BASE
    2. OPENC3_SERVICE_PASSWORD


### PR DESCRIPTION
## Summary
- Add reference to docs.openc3.com security page for detailed credential explanations and security best practices

Related to OpenC3/cosmos#2538

🤖 Generated with [Claude Code](https://claude.com/claude-code)